### PR TITLE
Add /snowflake command

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -68,11 +68,11 @@
           "hu/translation",
           "en-US/translation"
         ],
-        "jsonBaseURIs": [
-          {
-            "baseURI": "./src/locales/"
-          }
-        ]
+        // "jsonBaseURIs": [
+        //   {
+        //     "baseURI": "./src/locales"
+        //   }
+        // ]
       }
     ]
   }

--- a/.eslintrc
+++ b/.eslintrc
@@ -68,11 +68,11 @@
           "hu/translation",
           "en-US/translation"
         ],
-        // "jsonBaseURIs": [
-        //   {
-        //     "baseURI": "./src/locales"
-        //   }
-        // ]
+        "jsonBaseURIs": [
+          {
+            "baseURI": "./src/locales"
+          }
+        ]
       }
     ]
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "shell-escape": "^0.2.0",
         "tslib": "^2.3.0",
         "utf-8-validate": "^5.0.5",
-        "zlib-sync": "^0.1.7"
+        "zlib-sync": "^0.1.8"
       },
       "devDependencies": {
         "@types/i18next-fs-backend": "^1.1.2",
@@ -6301,9 +6301,9 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "node_modules/nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -8675,12 +8675,12 @@
       }
     },
     "node_modules/zlib-sync": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/zlib-sync/-/zlib-sync-0.1.7.tgz",
-      "integrity": "sha512-UmciU6ZrIwtwPC8noMzq+kGMdiWwNRZ3wC0SbED4Ew5Ikqx14MqDPRs/Pbk+3rZPh5SzsOgUBs1WRE0iieddpg==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/zlib-sync/-/zlib-sync-0.1.8.tgz",
+      "integrity": "sha512-Xbu4odT5SbLsa1HFz8X/FvMgUbJYWxJYKB2+bqxJ6UOIIPaVGrqHEB3vyXDltSA6tTqBhSGYLgiVpzPQHYi3lA==",
       "hasInstallScript": true,
       "dependencies": {
-        "nan": "^2.14.0"
+        "nan": "^2.17.0"
       }
     }
   },
@@ -13443,9 +13443,9 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -15143,11 +15143,11 @@
       "dev": true
     },
     "zlib-sync": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/zlib-sync/-/zlib-sync-0.1.7.tgz",
-      "integrity": "sha512-UmciU6ZrIwtwPC8noMzq+kGMdiWwNRZ3wC0SbED4Ew5Ikqx14MqDPRs/Pbk+3rZPh5SzsOgUBs1WRE0iieddpg==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/zlib-sync/-/zlib-sync-0.1.8.tgz",
+      "integrity": "sha512-Xbu4odT5SbLsa1HFz8X/FvMgUbJYWxJYKB2+bqxJ6UOIIPaVGrqHEB3vyXDltSA6tTqBhSGYLgiVpzPQHYi3lA==",
       "requires": {
-        "nan": "^2.14.0"
+        "nan": "^2.17.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hammertimebot",
   "version": "1.0.0",
-  "description": "Chat bot for the MLP Vector Club's Discord server",
+  "description": "Discord bot version of https://hammertime.cyou using slash commands",
   "author": "DJDavid98 <djdavid98@protonmail.com> (https://github.com/DJDavid98)",
   "private": true,
   "type": "module",
@@ -38,7 +38,7 @@
     "shell-escape": "^0.2.0",
     "tslib": "^2.3.0",
     "utf-8-validate": "^5.0.5",
-    "zlib-sync": "^0.1.7"
+    "zlib-sync": "^0.1.8"
   },
   "devDependencies": {
     "@types/i18next-fs-backend": "^1.1.2",

--- a/src/commands/snowflake.command.ts
+++ b/src/commands/snowflake.command.ts
@@ -1,0 +1,49 @@
+import moment from "moment";
+import { getSnowflakeCommandOptions } from "../options/snowflake.options.js";
+import { BotCommand } from "../types/bot-interaction.js";
+import { SnowflakeCommandOptionName } from "../types/localization.js";
+import { getLocalizedObject } from "../utils/get-localized-object.js";
+import { replyWithSyntax } from "../utils/reply-with-syntax.js";
+
+const DISCORD_EPOCH = 1420070400000;
+
+export const snowflakeCommand: BotCommand = {
+    getDefinition: (t) => ({
+    ...getLocalizedObject('description', (lng) => t('commands.snowflake.description', { lng })),
+    ...getLocalizedObject('name', (lng) => t('commands.snowflake.name', { lng })),
+    options: getSnowflakeCommandOptions(t),
+  }),
+  async handle(interaction, t) {
+    let snowflake = interaction.options.getString(SnowflakeCommandOptionName.VALUE, true);
+    let unixValue;
+    try {
+        unixValue = snowflakeToUnix(snowflake);
+    } catch(e) {
+        await interaction.reply({
+            content: t('commands.snowflake.responses.invalidSnowflake'),
+            ephemeral: true,
+        })
+        return;
+    }
+    const localMoment = moment.unix(unixValue).utc();
+
+    await replyWithSyntax(localMoment, interaction, t);
+  },
+};
+
+function snowflakeToUnix(snowflake: string) {
+    let snowflakeNumber;
+    try {
+        snowflakeNumber = BigInt(snowflake);
+    } catch(e) {
+        throw new Error('Invalid snowflake. Snowflakes must be a valid number.')
+    }
+
+    if (snowflakeNumber < 4194304) {
+        throw new Error('Invalid snowflake. Snowflakes must be greater than 4194303.');
+    }
+
+
+
+    return (Number(BigInt(snowflake) >> 22n) + DISCORD_EPOCH) / 1000;
+}

--- a/src/commands/snowflake.command.ts
+++ b/src/commands/snowflake.command.ts
@@ -4,8 +4,7 @@ import { BotCommand } from '../types/bot-interaction.js';
 import { SnowflakeCommandOptionName } from '../types/localization.js';
 import { getLocalizedObject } from '../utils/get-localized-object.js';
 import { replyWithSyntax } from '../utils/reply-with-syntax.js';
-
-const DISCORD_EPOCH = 1420070400000;
+import snowflakeToUnix from '../utils/snowflake.js';
 
 export const snowflakeCommand: BotCommand = {
   getDefinition: (t) => ({
@@ -30,20 +29,3 @@ export const snowflakeCommand: BotCommand = {
     await replyWithSyntax(localMoment, interaction, t);
   },
 };
-
-function snowflakeToUnix(snowflake: string) {
-  let snowflakeNumber;
-  try {
-    snowflakeNumber = BigInt(snowflake);
-  } catch (e) {
-    throw new Error('Invalid snowflake. Snowflakes must be a valid number.');
-  }
-
-  if (snowflakeNumber < 4194304) {
-    throw new Error('Invalid snowflake. Snowflakes must be greater than 4194303.');
-  }
-
-
-
-  return (Number(BigInt(snowflake) >> 22n) + DISCORD_EPOCH) / 1000;
-}

--- a/src/commands/snowflake.command.ts
+++ b/src/commands/snowflake.command.ts
@@ -1,29 +1,29 @@
-import moment from "moment";
-import { getSnowflakeCommandOptions } from "../options/snowflake.options.js";
-import { BotCommand } from "../types/bot-interaction.js";
-import { SnowflakeCommandOptionName } from "../types/localization.js";
-import { getLocalizedObject } from "../utils/get-localized-object.js";
-import { replyWithSyntax } from "../utils/reply-with-syntax.js";
+import moment from 'moment';
+import { getSnowflakeCommandOptions } from '../options/snowflake.options.js';
+import { BotCommand } from '../types/bot-interaction.js';
+import { SnowflakeCommandOptionName } from '../types/localization.js';
+import { getLocalizedObject } from '../utils/get-localized-object.js';
+import { replyWithSyntax } from '../utils/reply-with-syntax.js';
 
 const DISCORD_EPOCH = 1420070400000;
 
 export const snowflakeCommand: BotCommand = {
-    getDefinition: (t) => ({
+  getDefinition: (t) => ({
     ...getLocalizedObject('description', (lng) => t('commands.snowflake.description', { lng })),
     ...getLocalizedObject('name', (lng) => t('commands.snowflake.name', { lng })),
     options: getSnowflakeCommandOptions(t),
   }),
   async handle(interaction, t) {
-    let snowflake = interaction.options.getString(SnowflakeCommandOptionName.VALUE, true);
+    const snowflake = interaction.options.getString(SnowflakeCommandOptionName.VALUE, true);
     let unixValue;
     try {
-        unixValue = snowflakeToUnix(snowflake);
-    } catch(e) {
-        await interaction.reply({
-            content: t('commands.snowflake.responses.invalidSnowflake'),
-            ephemeral: true,
-        })
-        return;
+      unixValue = snowflakeToUnix(snowflake);
+    } catch (e) {
+      await interaction.reply({
+        content: t('commands.snowflake.responses.invalidSnowflake'),
+        ephemeral: true,
+      });
+      return;
     }
     const localMoment = moment.unix(unixValue).utc();
 
@@ -32,18 +32,18 @@ export const snowflakeCommand: BotCommand = {
 };
 
 function snowflakeToUnix(snowflake: string) {
-    let snowflakeNumber;
-    try {
-        snowflakeNumber = BigInt(snowflake);
-    } catch(e) {
-        throw new Error('Invalid snowflake. Snowflakes must be a valid number.')
-    }
+  let snowflakeNumber;
+  try {
+    snowflakeNumber = BigInt(snowflake);
+  } catch (e) {
+    throw new Error('Invalid snowflake. Snowflakes must be a valid number.');
+  }
 
-    if (snowflakeNumber < 4194304) {
-        throw new Error('Invalid snowflake. Snowflakes must be greater than 4194303.');
-    }
+  if (snowflakeNumber < 4194304) {
+    throw new Error('Invalid snowflake. Snowflakes must be greater than 4194303.');
+  }
 
 
 
-    return (Number(BigInt(snowflake) >> 22n) + DISCORD_EPOCH) / 1000;
+  return (Number(BigInt(snowflake) >> 22n) + DISCORD_EPOCH) / 1000;
 }

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -188,6 +188,19 @@
         }
       }
     },
+    "snowflake": {
+      "name": "snowflake",
+      "description": "Display the syntaxes for a specific Discord snowflake",
+      "responses": {
+        "invalidSnowflake": "The specified snowflake is invalid"
+      },
+      "options": {
+        "value": {
+          "name": "value",
+          "description": "The Discord snowflake"
+        }
+      }
+    },
     "global": {
       "responses": {
         "invalidDate": "The specified date is invalid (for example: the given day does not exist)"

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -188,19 +188,6 @@
         }
       }
     },
-    "snowflake": {
-      "name": "snowflake",
-      "description": "Display the syntax for the timestamp of a Snowflake (most IDs within Discord)",
-      "responses": {
-        "invalidSnowflake": "The specified snowflake is invalid"
-      },
-      "options": {
-        "value": {
-          "name": "value",
-          "description": "The Snowflake number"
-        }
-      }
-    },
     "global": {
       "responses": {
         "invalidDate": "The specified date is invalid (for example: the given day does not exist)"
@@ -251,6 +238,19 @@
         "noShards": "(The bot is not currently using sharding)",
         "serverInvite": "Support server invite URL:",
         "totalUserCount": "Total users in joined servers:"
+      }
+    },
+    "snowflake": {
+      "name": "snowflake",
+      "description": "Display the syntax for the timestamp of a Snowflake (most IDs within Discord)",
+      "responses": {
+        "invalidSnowflake": "The specified Snowflake is invalid"
+      },
+      "options": {
+        "value": {
+          "name": "value",
+          "description": "The Snowflake number"
+        }
       }
     }
   }

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -190,14 +190,14 @@
     },
     "snowflake": {
       "name": "snowflake",
-      "description": "Display the syntaxes for a specific Discord snowflake",
+      "description": "Display the syntax for the timestamp of a Snowflake (most IDs within Discord)",
       "responses": {
         "invalidSnowflake": "The specified snowflake is invalid"
       },
       "options": {
         "value": {
           "name": "value",
-          "description": "The Discord snowflake"
+          "description": "The Snowflake number"
         }
       }
     },

--- a/src/options/snowflake.options.ts
+++ b/src/options/snowflake.options.ts
@@ -1,16 +1,16 @@
-import { APIApplicationCommandBasicOption, ApplicationCommandOptionType } from "discord.js";
-import { TFunction } from "i18next";
-import { SnowflakeCommandOptionName } from "../types/localization.js";
-import { getLocalizedObject } from "../utils/get-localized-object.js";
-import { getGlobalOptions } from "./global.options.js";
+import { APIApplicationCommandBasicOption, ApplicationCommandOptionType } from 'discord.js';
+import { TFunction } from 'i18next';
+import { SnowflakeCommandOptionName } from '../types/localization.js';
+import { getLocalizedObject } from '../utils/get-localized-object.js';
+import { getGlobalOptions } from './global.options.js';
 
 export const getSnowflakeCommandOptions = (t: TFunction): APIApplicationCommandBasicOption[] => [
-    {
-        name: SnowflakeCommandOptionName.VALUE,
-        ...getLocalizedObject('name', (lng) => t('commands.snowflake.options.value.name', { lng }), false),
-        ...getLocalizedObject('description', (lng) => t('commands.snowflake.options.value.description', { lng })),
-        type: ApplicationCommandOptionType.String,
-        required: true,
-    },
-    ...getGlobalOptions(t),
+  {
+    name: SnowflakeCommandOptionName.VALUE,
+    ...getLocalizedObject('name', (lng) => t('commands.snowflake.options.value.name', { lng }), false),
+    ...getLocalizedObject('description', (lng) => t('commands.snowflake.options.value.description', { lng })),
+    type: ApplicationCommandOptionType.String,
+    required: true,
+  },
+  ...getGlobalOptions(t),
 ];

--- a/src/options/snowflake.options.ts
+++ b/src/options/snowflake.options.ts
@@ -1,0 +1,16 @@
+import { APIApplicationCommandBasicOption, ApplicationCommandOptionType } from "discord.js";
+import { TFunction } from "i18next";
+import { SnowflakeCommandOptionName } from "../types/localization.js";
+import { getLocalizedObject } from "../utils/get-localized-object.js";
+import { getGlobalOptions } from "./global.options.js";
+
+export const getSnowflakeCommandOptions = (t: TFunction): APIApplicationCommandBasicOption[] => [
+    {
+        name: SnowflakeCommandOptionName.VALUE,
+        ...getLocalizedObject('name', (lng) => t('commands.snowflake.options.value.name', { lng }), false),
+        ...getLocalizedObject('description', (lng) => t('commands.snowflake.options.value.description', { lng })),
+        type: ApplicationCommandOptionType.String,
+        required: true,
+    },
+    ...getGlobalOptions(t),
+];

--- a/src/types/bot-interaction.ts
+++ b/src/types/bot-interaction.ts
@@ -7,11 +7,11 @@ export enum BotCommandName {
   AGO = 'ago',
   AT = 'at',
   IN = 'in',
+  SNOWFLAKE = 'snowflake',
   STATISTICS = 'statistics',
   SUBTRACT = 'subtract',
   TIMESTAMP = 'timestamp',
   UNIX = 'unix',
-  SNOWFLAKE = 'snowflake'
 }
 
 export type BotCommandDefinition = Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'type'>;

--- a/src/types/bot-interaction.ts
+++ b/src/types/bot-interaction.ts
@@ -11,6 +11,7 @@ export enum BotCommandName {
   SUBTRACT = 'subtract',
   TIMESTAMP = 'timestamp',
   UNIX = 'unix',
+  SNOWFLAKE = 'snowflake'
 }
 
 export type BotCommandDefinition = Omit<RESTPostAPIChatInputApplicationCommandsJSONBody, 'type'>;

--- a/src/types/localization.ts
+++ b/src/types/localization.ts
@@ -61,6 +61,10 @@ export enum UnixCommandOptionName {
   VALUE = 'value',
 }
 
+export enum SnowflakeCommandOptionName {
+  VALUE = 'value',
+}
+
 interface CommandOptionsMap {
   [BotCommandName.TIMESTAMP]: never,
   [BotCommandName.IN]: InCommandOptionName,

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -14,6 +14,7 @@ import { statisticsCommand } from '../commands/statistics.command.js';
 import { subtractCommand } from '../commands/subtract.command.js';
 import { timestampCommand } from '../commands/timestamp.command.js';
 import { unixCommand } from '../commands/unix.command.js';
+import { snowflakeCommand } from '../commands/snowflake.command.js';
 
 export const commandMap: Record<BotCommandName, BotCommand> = {
   [BotCommandName.ADD]: addCommand,
@@ -24,6 +25,7 @@ export const commandMap: Record<BotCommandName, BotCommand> = {
   [BotCommandName.SUBTRACT]: subtractCommand,
   [BotCommandName.TIMESTAMP]: timestampCommand,
   [BotCommandName.UNIX]: unixCommand,
+  [BotCommandName.SNOWFLAKE]: snowflakeCommand,
 };
 
 export const commandNames = (Object.keys(commandMap) as BotCommandName[]);

--- a/src/utils/snowflake.test.ts
+++ b/src/utils/snowflake.test.ts
@@ -1,0 +1,26 @@
+import snowflakeToUnix from './snowflake.js';
+
+describe('snowflakteToUnix', () => {
+  it('should convert a snowflake to a unix timestamp', () => {
+    expect(snowflakeToUnix('996673713938366504')).toEqual(1657695930);
+    expect(snowflakeToUnix('1005505184094507048')).toEqual(1659801517);
+    expect(snowflakeToUnix('1006946901482029096')).toEqual(1660145249);
+    expect(snowflakeToUnix('1052750665581088768')).toEqual(1671065717);
+    expect(snowflakeToUnix('140360880079503362')).toEqual(1453535041);
+    expect(snowflakeToUnix('138353487208644608')).toEqual(1453056441);
+    expect(snowflakeToUnix('0x1EB87C37A81FFF8')).toEqual(1453056441);
+    expect(snowflakeToUnix('4194304')).toEqual(1420070400);
+  });
+  it('should throw an error if the snowflake is invalid', () => {
+    expect(() => snowflakeToUnix('invalid')).toThrow(new Error('Invalid snowflake. Snowflakes must be a valid number.'));
+    expect(() => snowflakeToUnix('')).toThrow(new Error('Invalid snowflake. Snowflakes must be a valid number.'));
+    expect(() => snowflakeToUnix('120312039NotANumber012021')).toThrow(new Error('Invalid snowflake. Snowflakes must be a valid number.'));
+    expect(() => snowflakeToUnix('one')).toThrow(new Error('Invalid snowflake. Snowflakes must be a valid number.'));
+  });
+  it('should throw an error if the snowflake is too small', () => {
+    expect(() => snowflakeToUnix('4194303')).toThrow(new Error('Invalid snowflake. Snowflakes must be greater than 4194303.'));
+    expect(() => snowflakeToUnix('0')).toThrow(new Error('Invalid snowflake. Snowflakes must be greater than 4194303.'));
+    expect(() => snowflakeToUnix('-10')).toThrow(new Error('Invalid snowflake. Snowflakes must be greater than 4194303.'));
+    expect(() => snowflakeToUnix('-138353487208644608')).toThrow(new Error('Invalid snowflake. Snowflakes must be greater than 4194303.'));
+  });
+});

--- a/src/utils/snowflake.test.ts
+++ b/src/utils/snowflake.test.ts
@@ -1,5 +1,8 @@
 import snowflakeToUnix from './snowflake.js';
 
+const INVALID_SNOWFLAKE_ERROR = new Error('Invalid snowflake. Snowflakes must be a valid number.');
+const INVALID_SNOWFLAKE_TOO_SMALL_ERROR = new Error('Invalid snowflake. Snowflakes must be greater than 4194303.');
+
 describe('snowflakteToUnix', () => {
   it('should convert a snowflake to a unix timestamp', () => {
     expect(snowflakeToUnix('996673713938366504')).toEqual(1657695930);
@@ -12,15 +15,15 @@ describe('snowflakteToUnix', () => {
     expect(snowflakeToUnix('4194304')).toEqual(1420070400);
   });
   it('should throw an error if the snowflake is invalid', () => {
-    expect(() => snowflakeToUnix('invalid')).toThrow(new Error('Invalid snowflake. Snowflakes must be a valid number.'));
-    expect(() => snowflakeToUnix('')).toThrow(new Error('Invalid snowflake. Snowflakes must be a valid number.'));
-    expect(() => snowflakeToUnix('120312039NotANumber012021')).toThrow(new Error('Invalid snowflake. Snowflakes must be a valid number.'));
-    expect(() => snowflakeToUnix('one')).toThrow(new Error('Invalid snowflake. Snowflakes must be a valid number.'));
+    expect(() => snowflakeToUnix('invalid')).toThrow(INVALID_SNOWFLAKE_ERROR);
+    expect(() => snowflakeToUnix('')).toThrow(INVALID_SNOWFLAKE_ERROR);
+    expect(() => snowflakeToUnix('120312039NotANumber012021')).toThrow(INVALID_SNOWFLAKE_ERROR);
+    expect(() => snowflakeToUnix('one')).toThrow(INVALID_SNOWFLAKE_ERROR);
   });
   it('should throw an error if the snowflake is too small', () => {
-    expect(() => snowflakeToUnix('4194303')).toThrow(new Error('Invalid snowflake. Snowflakes must be greater than 4194303.'));
-    expect(() => snowflakeToUnix('0')).toThrow(new Error('Invalid snowflake. Snowflakes must be greater than 4194303.'));
-    expect(() => snowflakeToUnix('-10')).toThrow(new Error('Invalid snowflake. Snowflakes must be greater than 4194303.'));
-    expect(() => snowflakeToUnix('-138353487208644608')).toThrow(new Error('Invalid snowflake. Snowflakes must be greater than 4194303.'));
+    expect(() => snowflakeToUnix('4194303')).toThrow(INVALID_SNOWFLAKE_TOO_SMALL_ERROR);
+    expect(() => snowflakeToUnix('0')).toThrow(INVALID_SNOWFLAKE_TOO_SMALL_ERROR);
+    expect(() => snowflakeToUnix('-10')).toThrow(INVALID_SNOWFLAKE_TOO_SMALL_ERROR);
+    expect(() => snowflakeToUnix('-138353487208644608')).toThrow(INVALID_SNOWFLAKE_TOO_SMALL_ERROR);
   });
 });

--- a/src/utils/snowflake.ts
+++ b/src/utils/snowflake.ts
@@ -1,0 +1,24 @@
+const DISCORD_EPOCH = 1420070400000;
+
+/**
+ * Converts a snowflake to a unix timestamp
+ * @param snowflake The snowflake to convert
+ * @returns A number with the unix timestamp
+ * @throws {Error} If the snowflake is invalid
+ */
+export default function snowflakeToUnix(snowflake: string) {
+  let snowflakeNumber;
+  try {
+    snowflakeNumber = BigInt(snowflake);
+  } catch (e) {
+    throw new Error('Invalid snowflake. Snowflakes must be a valid number.');
+  }
+
+  if (snowflakeNumber < 4194304) {
+    throw new Error('Invalid snowflake. Snowflakes must be greater than 4194303.');
+  }
+
+
+
+  return (Number(BigInt(snowflake) >> 22n) + DISCORD_EPOCH) / 1000;
+}

--- a/src/utils/snowflake.ts
+++ b/src/utils/snowflake.ts
@@ -18,7 +18,5 @@ export default function snowflakeToUnix(snowflake: string) {
     throw new Error('Invalid snowflake. Snowflakes must be greater than 4194303.');
   }
 
-
-
-  return (Number(BigInt(snowflake) >> 22n) + DISCORD_EPOCH) / 1000;
+  return Math.floor(((Number(BigInt(snowflakeNumber) >> 22n)) + DISCORD_EPOCH) / 1000);
 }

--- a/src/utils/snowflake.ts
+++ b/src/utils/snowflake.ts
@@ -7,10 +7,9 @@ const DISCORD_EPOCH = 1420070400000;
  * @throws {Error} If the snowflake is invalid
  */
 export default function snowflakeToUnix(snowflake: string) {
-  let snowflakeNumber;
-  try {
-    snowflakeNumber = BigInt(snowflake);
-  } catch (e) {
+  const snowflakeNumber = Number(snowflake);
+  
+  if (isNaN(snowflakeNumber) || snowflake.length === 0) {
     throw new Error('Invalid snowflake. Snowflakes must be a valid number.');
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "sourceMap": true,
     "strict": true,
     "target": "ES2020",
-    "module": "ES2020"
+    "module": "ES2020",
+    "forceConsistentCasingInFileNames": true,
   },
   "exclude": [
     "tests"


### PR DESCRIPTION
This command allows you to generate timestamps by giving it a snowflake id. Below is a gif of how it works:
![DiscordSnowflakeCommand](https://user-images.githubusercontent.com/58728143/225925421-7f21d663-eb75-46ed-a6ed-9d6ed37a6b37.gif)
(this pr does **not** include context menu commands)

Because discord snowflakes exceed the max limit of the `ApplicationCommandOptionType.Number` I had to resort to a string input. As you can see in the gif above, invalid snowflakes will be dealed with properly.

I have no idea if I implemented this properly. I tried to keep to the current structure as much as possible. I'm mainly worried about the translations not being done correctly, since I just added them to `src/locales/en-US/translation.json`. Feel free to change anything you don't like. Any feedback is welcome!